### PR TITLE
use DeepL API v2 as default

### DIFF
--- a/src/DeepL.php
+++ b/src/DeepL.php
@@ -132,7 +132,7 @@ class DeepL
      * @param string  $authKey
      * @param integer $apiVersion
      */
-    public function __construct($authKey, $apiVersion = 1)
+    public function __construct($authKey, $apiVersion = 2)
     {
         $this->authKey    = $authKey;
         $this->apiVersion = $apiVersion;
@@ -251,7 +251,7 @@ class DeepL
                 $url = DeepL::API_URL_V2;
                 break;
             default:
-                $url = DeepL::API_URL_V1;
+                $url = DeepL::API_URL_V2;
         }
 
         $url .= '?' . sprintf(DeepL::API_URL_AUTH_KEY, $this->authKey);

--- a/src/DeepL.php
+++ b/src/DeepL.php
@@ -12,27 +12,27 @@ class DeepL
     /**
      * API v1 URL
      */
-    const API_URL_V1               = 'https://api.deepl.com/v1/translate';
+    const API_URL_V1 = 'https://api.deepl.com/v1/translate';
 
     /**
      * API v2 URL
      */
-    const API_URL_V2               = 'https://api.deepl.com/v2/translate';
+    const API_URL_V2 = 'https://api.deepl.com/v2/translate';
 
     /**
      * API URL: Parameter auth_key
      */
-    const API_URL_AUTH_KEY         = 'auth_key=%s';
+    const API_URL_AUTH_KEY = 'auth_key=%s';
 
     /**
      * API URL: Parameter text
      */
-    const API_URL_TEXT             = 'text=%s';
+    const API_URL_TEXT = 'text=%s';
 
     /**
      * API URL: Parameter source_lang
      */
-    const API_URL_SOURCE_LANG      = 'source_lang=%s';
+    const API_URL_SOURCE_LANG = 'source_lang=%s';
 
     /**
      * API URL: Parameter target_lang
@@ -42,17 +42,17 @@ class DeepL
     /**
      * API URL: Parameter tag_handling
      */
-    const API_URL_TAG_HANDLING     = 'tag_handling=%s';
+    const API_URL_TAG_HANDLING = 'tag_handling=%s';
 
     /**
      * API URL: Parameter ignore_tags
      */
-    const API_URL_IGNORE_TAGS      = 'ignore_tags=%s';
+    const API_URL_IGNORE_TAGS = 'ignore_tags=%s';
 
     /**
      * API URL: Parameter formality
      */
-    const API_URL_FORMALITY        = 'formality=%s';
+    const API_URL_FORMALITY = 'formality=%s';
 
     /**
      * DeepL HTTP error codes

--- a/tests/DeepLTest.php
+++ b/tests/DeepLTest.php
@@ -113,7 +113,30 @@ class DeepLTest extends \PHPUnit_Framework_TestCase
             'formality' => 'default'
         ));
 
-        $deepl   = new DeepL($authKey);
+        $deepl = new DeepL($authKey);
+
+        $buildUrl = self::getMethod('\BabyMarkt\DeepL\DeepL', 'buildUrl');
+
+        $return = $buildUrl->invokeArgs($deepl, array('de', 'en'));
+
+        $this->assertEquals($expectedString, $return);
+    }
+
+    /**
+     * Test buildUrl()
+     */
+    public function testBuildUrlV1()
+    {
+        $authKey = '123456';
+
+        $expectedString = 'https://api.deepl.com/v1/translate?' . http_build_query(array(
+                'auth_key' => $authKey,
+                'source_lang' => 'de',
+                'target_lang' => 'en',
+                'formality' => 'default'
+            ));
+
+        $deepl = new DeepL($authKey, 1);
 
         $buildUrl = self::getMethod('\BabyMarkt\DeepL\DeepL', 'buildUrl');
 
@@ -137,7 +160,31 @@ class DeepLTest extends \PHPUnit_Framework_TestCase
             'formality' => 'default'
         ));
 
-        $deepl   = new DeepL($authKey);
+        $deepl = new DeepL($authKey);
+
+        $buildUrl = self::getMethod('\BabyMarkt\DeepL\DeepL', 'buildUrl');
+
+        $return = $buildUrl->invokeArgs($deepl, array('de', 'en', array('xml'), array('x')));
+
+        $this->assertEquals($expectedString, $return);
+    }
+
+    /**
+     * Test buildUrl()
+     */
+    public function testBuildUrlWithTagsV1()
+    {
+        $authKey = '123456';
+        $expectedString = 'https://api.deepl.com/v1/translate?' . http_build_query(array(
+                'auth_key' => $authKey,
+                'source_lang' => 'de',
+                'target_lang' => 'en',
+                'tag_handling' => 'xml',
+                'ignore_tags' => 'x',
+                'formality' => 'default'
+            ));
+
+        $deepl = new DeepL($authKey, 1);
 
         $buildUrl = self::getMethod('\BabyMarkt\DeepL\DeepL', 'buildUrl');
 
@@ -196,6 +243,27 @@ class DeepLTest extends \PHPUnit_Framework_TestCase
         }
 
         $deepl = new DeepL(self::$authKey, 1);
+
+        $germanText     = 'Hallo Welt';
+        $expectedText   = 'Hello World';
+
+        $translatedText = $deepl->translate($germanText);
+
+        $this->assertEquals($expectedText, $translatedText);
+    }
+
+    /**
+     * Test translate() success with default v2 API
+     *
+     * TEST REQUIRES VALID DEEPL AUTH KEY!!
+     */
+    public function testTranslateWrongVersionSuccess()
+    {
+        if (self::$authKey === false) {
+            $this->markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
+        }
+
+        $deepl = new DeepL(self::$authKey, 3);
 
         $germanText     = 'Hallo Welt';
         $expectedText   = 'Hello World';

--- a/tests/DeepLTest.php
+++ b/tests/DeepLTest.php
@@ -106,7 +106,7 @@ class DeepLTest extends \PHPUnit_Framework_TestCase
     {
         $authKey = '123456';
 
-        $expectedString = 'https://api.deepl.com/v1/translate?' . http_build_query(array(
+        $expectedString = 'https://api.deepl.com/v2/translate?' . http_build_query(array(
             'auth_key' => $authKey,
             'source_lang' => 'de',
             'target_lang' => 'en',
@@ -128,7 +128,7 @@ class DeepLTest extends \PHPUnit_Framework_TestCase
     public function testBuildUrlWithTags()
     {
         $authKey = '123456';
-        $expectedString = 'https://api.deepl.com/v1/translate?' . http_build_query(array(
+        $expectedString = 'https://api.deepl.com/v2/translate?' . http_build_query(array(
             'auth_key' => $authKey,
             'source_lang' => 'de',
             'target_lang' => 'en',
@@ -164,7 +164,7 @@ class DeepLTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Test translate() success
+     * Test translate() success with v2 API
      *
      * TEST REQUIRES VALID DEEPL AUTH KEY!!
      */
@@ -185,17 +185,17 @@ class DeepLTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Test translate() success with v2 API
+     * Test translate() success with v1 API
      *
      * TEST REQUIRES VALID DEEPL AUTH KEY!!
      */
-    public function testTranslateV2Success()
+    public function testTranslateV1Success()
     {
         if (self::$authKey === false) {
             $this->markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
         }
 
-        $deepl = new DeepL(self::$authKey, 2);
+        $deepl = new DeepL(self::$authKey, 1);
 
         $germanText     = 'Hallo Welt';
         $expectedText   = 'Hello World';


### PR DESCRIPTION
"Version 1 (v1) of the DeepL API is not supported by the DeepL API plan available from October 2018. Please use version 2 for all new products other than CAT tool integrations."
from https://www.deepl.com/docs-api/accessing-the-api/api-versions/

"Currently, the two DeepL API versions differ only in the URL used for access."