### PR TITLE
Show curl error in the exception if cURL request failed

### DIFF
--- a/src/DeepL.php
+++ b/src/DeepL.php
@@ -249,7 +249,7 @@ class DeepL
         $response = curl_exec($this->curl);
 
         if (curl_errno($this->curl)) {
-            throw new DeepLException('There was a cURL Request Error :' . curl_error($this->curl));
+            throw new DeepLException('There was a cURL Request Error : ' . curl_error($this->curl));
         }
         $httpCode      = curl_getinfo($this->curl, CURLINFO_HTTP_CODE);
         $responseArray = json_decode($response, true);

--- a/src/DeepL.php
+++ b/src/DeepL.php
@@ -249,7 +249,7 @@ class DeepL
         $response = curl_exec($this->curl);
 
         if (curl_errno($this->curl)) {
-            throw new DeepLException('There was a cURL Request Error.');
+            throw new DeepLException('There was a cURL Request Error :' . curl_error($this->curl));
         }
         $httpCode      = curl_getinfo($this->curl, CURLINFO_HTTP_CODE);
         $responseArray = json_decode($response, true);


### PR DESCRIPTION
I had some issues debugging a failing request. It's much easier if the Exception actually tells us what went wrong.