### PR TITLE
PHP 8.0 support by Babymarkt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,18 +2,9 @@ language: php
 
 matrix:
   include:
-    - php: 5.3
-      dist: precise
-    - php: 5.4
-      dist: precise
-    - php: 5.5
-      dist: precise
-    - php: 5.6
-    - php: 7.0
-    - php: 7.1
-    - php: 7.2
     - php: 7.3
-    - php: 7.4snapshot
+    - php: 7.4
+    - php: 8.0
     - php: nightly
   allow_failures:
     - php: nightly

--- a/composer.json
+++ b/composer.json
@@ -19,14 +19,14 @@
         }
     ],
     "require": {
-        "php": ">=5.3 <8.0",
+        "php": ">=7.3 <8.1",
         "ext-json": "*",
         "ext-curl": "*"
     },
     "require-dev": {
-        "phpmd/phpmd": "2.4.*",
-        "phpunit/phpunit": "^4.8",
-        "squizlabs/php_codesniffer": "^2.9"
+        "phpmd/phpmd": "^2.10",
+        "phpunit/phpunit": "^9",
+        "squizlabs/php_codesniffer": "^3"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "babymarkt/deepl-php-lib",
     "type": "library",
-    "description": "DeepL API Client Library supporting PHP >= 5.3 && PHP < 8.0",
+    "description": "DeepL API Client Library supporting PHP >= 7.3 && PHP < 8.1",
     "keywords": [
       "babymarkt",
       "deepl",

--- a/src/DeepL.php
+++ b/src/DeepL.php
@@ -2,6 +2,8 @@
 
 namespace BabyMarkt\DeepL;
 
+use InvalidArgumentException;
+
 /**
  * DeepL API client library
  *
@@ -133,7 +135,7 @@ class DeepL
         array $splittingTags = null
     ) {
         if (is_array($tagHandling)) {
-            throw new \InvalidArgumentException('$tagHandling must be of type String in V2 of DeepLLibrary');
+            throw new InvalidArgumentException('$tagHandling must be of type String in V2 of DeepLLibrary');
         }
         $paramsArray = array(
             'text'                => $text,

--- a/tests/integration/DeepLApiTest.php
+++ b/tests/integration/DeepLApiTest.php
@@ -3,7 +3,7 @@
 namespace BabyMarkt\DeepL\integration;
 
 use BabyMarkt\DeepL\DeepL;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 
 /**
@@ -12,7 +12,7 @@ use ReflectionClass;
  * @package BabyMarkt\DeepL
  * @SuppressWarnings(PHPMD.TooManyPublicMethods)
  */
-class DeepLApiTest extends PHPUnit_Framework_TestCase
+class DeepLApiTest extends TestCase
 {
     /**
      * DeepL Auth Key.
@@ -24,7 +24,7 @@ class DeepLApiTest extends PHPUnit_Framework_TestCase
     /**
      * Setup DeepL Auth Key.
      */
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
 
@@ -62,7 +62,7 @@ class DeepLApiTest extends PHPUnit_Framework_TestCase
     public function testTranslateSuccess()
     {
         if (self::$authKey === false) {
-            $this->markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
+            self::markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
         }
 
         $deepl = new DeepL(self::$authKey);
@@ -72,7 +72,7 @@ class DeepLApiTest extends PHPUnit_Framework_TestCase
 
         $translatedText = $deepl->translate($germanText);
 
-        $this->assertEquals($expectedText, $translatedText[0]['text']);
+        self::assertEquals($expectedText, $translatedText[0]['text']);
     }
 
     /**
@@ -81,7 +81,7 @@ class DeepLApiTest extends PHPUnit_Framework_TestCase
     public function testTranslateV1Success()
     {
         if (self::$authKey === false) {
-            $this->markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
+            self::markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
         }
 
         $deepl = new DeepL(self::$authKey, 1);
@@ -91,7 +91,7 @@ class DeepLApiTest extends PHPUnit_Framework_TestCase
 
         $translatedText = $deepl->translate($germanText);
 
-        $this->assertEquals($expectedText, $translatedText[0]['text']);
+        self::assertEquals($expectedText, $translatedText[0]['text']);
     }
 
     /**
@@ -100,12 +100,12 @@ class DeepLApiTest extends PHPUnit_Framework_TestCase
     public function testTranslateWrongVersion()
     {
         if (self::$authKey === false) {
-            $this->markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
+            self::markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
         }
         $germanText = 'Hallo Welt';
         $deepl      = new DeepL(self::$authKey, 3);
 
-        $this->setExpectedException('\BabyMarkt\DeepL\DeepLException');
+        $this->expectException('\BabyMarkt\DeepL\DeepLException');
 
         $deepl->translate($germanText);
     }
@@ -116,7 +116,7 @@ class DeepLApiTest extends PHPUnit_Framework_TestCase
     public function testTranslateTagHandlingSuccess()
     {
         if (self::$authKey === false) {
-            $this->markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
+            self::markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
         }
 
         $deepl = new DeepL(self::$authKey);
@@ -131,7 +131,7 @@ class DeepLApiTest extends PHPUnit_Framework_TestCase
             'xml'
         );
 
-        $this->assertEquals($expectedText, $translatedText[0]['text']);
+        self::assertEquals($expectedText, $translatedText[0]['text']);
     }
 
     /**
@@ -140,7 +140,7 @@ class DeepLApiTest extends PHPUnit_Framework_TestCase
     public function testTranslateIgnoreTagsSuccess()
     {
         if (self::$authKey === false) {
-            $this->markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
+            self::markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
         }
 
         $deepl = new DeepL(self::$authKey);
@@ -156,7 +156,7 @@ class DeepLApiTest extends PHPUnit_Framework_TestCase
             array('strong')
         );
 
-        $this->assertEquals($expectedText, $translatedText[0]['text']);
+        self::assertEquals($expectedText, $translatedText[0]['text']);
     }
 
     /**
@@ -165,14 +165,14 @@ class DeepLApiTest extends PHPUnit_Framework_TestCase
     public function testUsage()
     {
         if (self::$authKey === false) {
-            $this->markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
+            self::markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
         }
 
         $deepl    = new DeepL(self::$authKey);
         $response = $deepl->usage();
 
-        $this->assertArrayHasKey('character_count', $response);
-        $this->assertArrayHasKey('character_limit', $response);
+        self::assertArrayHasKey('character_count', $response);
+        self::assertArrayHasKey('character_limit', $response);
     }
 
     /**
@@ -181,15 +181,15 @@ class DeepLApiTest extends PHPUnit_Framework_TestCase
     public function testLanguages()
     {
         if (self::$authKey === false) {
-            $this->markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
+            self::markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
         }
 
         $deepl    = new DeepL(self::$authKey);
         $response = $deepl->languages();
 
         foreach ($response as $language) {
-            $this->assertArrayHasKey('language', $language);
-            $this->assertArrayHasKey('name', $language);
+            self::assertArrayHasKey('language', $language);
+            self::assertArrayHasKey('name', $language);
         }
     }
 
@@ -199,15 +199,15 @@ class DeepLApiTest extends PHPUnit_Framework_TestCase
     public function testLanguagesSource()
     {
         if (self::$authKey === false) {
-            $this->markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
+            self::markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
         }
 
         $deepl    = new DeepL(self::$authKey);
         $response = $deepl->languages('source');
 
         foreach ($response as $language) {
-            $this->assertArrayHasKey('language', $language);
-            $this->assertArrayHasKey('name', $language);
+            self::assertArrayHasKey('language', $language);
+            self::assertArrayHasKey('name', $language);
         }
     }
 
@@ -217,15 +217,15 @@ class DeepLApiTest extends PHPUnit_Framework_TestCase
     public function testLanguagesTarget()
     {
         if (self::$authKey === false) {
-            $this->markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
+            self::markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
         }
 
         $deepl    = new DeepL(self::$authKey);
         $response = $deepl->languages('target');
 
         foreach ($response as $language) {
-            $this->assertArrayHasKey('language', $language);
-            $this->assertArrayHasKey('name', $language);
+            self::assertArrayHasKey('language', $language);
+            self::assertArrayHasKey('name', $language);
         }
     }
 
@@ -235,12 +235,12 @@ class DeepLApiTest extends PHPUnit_Framework_TestCase
     public function testLanguagesFail()
     {
         if (self::$authKey === false) {
-            $this->markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
+            self::markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
         }
 
         $deepl    = new DeepL(self::$authKey);
 
-        $this->setExpectedException('\BabyMarkt\DeepL\DeepLException');
+        $this->expectException('\BabyMarkt\DeepL\DeepLException');
 
         $deepl->languages('fail');
     }
@@ -251,7 +251,7 @@ class DeepLApiTest extends PHPUnit_Framework_TestCase
     public function testTranslateWithAllParams()
     {
         if (self::$authKey === false) {
-            $this->markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
+            self::markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
         }
 
         $deepl = new DeepL(self::$authKey);
@@ -273,7 +273,7 @@ class DeepLApiTest extends PHPUnit_Framework_TestCase
             array('p','br')                //$splittingTags
         );
 
-        $this->assertEquals($expectedText, $translatedText[0]['text']);
+        self::assertEquals($expectedText, $translatedText[0]['text']);
     }
 
     /**
@@ -282,7 +282,7 @@ class DeepLApiTest extends PHPUnit_Framework_TestCase
     public function testTranslateFormality()
     {
         if (self::$authKey === false) {
-            $this->markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
+            self::markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
         }
 
         $deepl = new DeepL(self::$authKey);
@@ -298,7 +298,7 @@ class DeepLApiTest extends PHPUnit_Framework_TestCase
             'less'                         //$formality
         );
 
-        $this->assertEquals($expectedText, $translatedText[0]['text']);
+        self::assertEquals($expectedText, $translatedText[0]['text']);
     }
 
     /**
@@ -307,13 +307,13 @@ class DeepLApiTest extends PHPUnit_Framework_TestCase
     public function testTranslateFormalityFail()
     {
         if (self::$authKey === false) {
-            $this->markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
+            self::markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
         }
 
         $deepl        = new DeepL(self::$authKey);
         $englishText  = '<strong>text to do not translate</strong><p>please translate this text</p>';
 
-        $this->setExpectedException('\BabyMarkt\DeepL\DeepLException');
+        self::setExpectedException('\BabyMarkt\DeepL\DeepLException');
 
         $deepl->translate(
             $englishText,
@@ -332,7 +332,7 @@ class DeepLApiTest extends PHPUnit_Framework_TestCase
     public function testTranslateWithHTML()
     {
         if (self::$authKey === false) {
-            $this->markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
+            self::markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
         }
 
         $deepl           = new DeepL(self::$authKey);
@@ -367,7 +367,7 @@ class DeepLApiTest extends PHPUnit_Framework_TestCase
             array('p')
         );
 
-        $this->assertEquals($expectedArray, $translatedText);
+        self::assertEquals($expectedArray, $translatedText);
     }
 
     /**
@@ -376,12 +376,12 @@ class DeepLApiTest extends PHPUnit_Framework_TestCase
     public function testTranslateWithNotSupportedSourceLanguage()
     {
         if (self::$authKey === false) {
-            $this->markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
+            self::markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
         }
 
         $deepl = new DeepL(self::$authKey);
 
-        $this->setExpectedException('\BabyMarkt\DeepL\DeepLException');
+        $this->expectException('\BabyMarkt\DeepL\DeepLException');
         $deepl->translate('some txt', 'dk', 'de');
     }
 
@@ -391,12 +391,12 @@ class DeepLApiTest extends PHPUnit_Framework_TestCase
     public function testTranslateWithNotSupportedDestinationLanguage()
     {
         if (self::$authKey === false) {
-            $this->markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
+            self::markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
         }
 
         $deepl = new DeepL(self::$authKey);
 
-        $this->setExpectedException('\BabyMarkt\DeepL\DeepLException');
+        $this->expectException('\BabyMarkt\DeepL\DeepLException');
         $deepl->translate('some txt', 'en', 'dk');
     }
 }

--- a/tests/integration/DeepLApiTest.php
+++ b/tests/integration/DeepLApiTest.php
@@ -302,31 +302,6 @@ class DeepLApiTest extends TestCase
     }
 
     /**
-     * Test translate() $formality
-     */
-    public function testTranslateFormalityFail()
-    {
-        if (self::$authKey === false) {
-            self::markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
-        }
-
-        $deepl        = new DeepL(self::$authKey);
-        $englishText  = '<strong>text to do not translate</strong><p>please translate this text</p>';
-
-        $this->expectException('\BabyMarkt\DeepL\DeepLException');
-
-        $deepl->translate(
-            $englishText,
-            'en',           //$sourceLanguage
-            'es',        //$destinationLanguage
-            null,             //$tagHandling
-            null, //$ignoreTags
-            'more'                         //$formality
-        );
-    }
-
-
-    /**
      * Test to Test the Tag-Handling.
      */
     public function testTranslateWithHTML()

--- a/tests/integration/DeepLApiTest.php
+++ b/tests/integration/DeepLApiTest.php
@@ -68,7 +68,7 @@ class DeepLApiTest extends TestCase
         $deepl = new DeepL(self::$authKey);
 
         $germanText     = 'Hallo Welt';
-        $expectedText   = 'Hello World';
+        $expectedText   = 'Hello world';
 
         $translatedText = $deepl->translate($germanText);
 
@@ -87,7 +87,7 @@ class DeepLApiTest extends TestCase
         $deepl = new DeepL(self::$authKey, 1);
 
         $germanText     = 'Hallo Welt';
-        $expectedText   = 'Hello World';
+        $expectedText   = 'Hello world';
 
         $translatedText = $deepl->translate($germanText);
 
@@ -288,7 +288,7 @@ class DeepLApiTest extends TestCase
         $deepl = new DeepL(self::$authKey);
 
         $englishText    = '<strong>text to do not translate</strong><p>please translate this text</p>';
-        $expectedText   = '<stark>nicht zu übersetzender Text</stark><p>bitte diesen Text übersetzen</p>';
+        $expectedText   = '<strong>Nicht zu übersetzender Text</strong><p>Bitte übersetze diesen Text</p>';
         $translatedText = $deepl->translate(
             $englishText,
             'en',           //$sourceLanguage
@@ -348,7 +348,7 @@ class DeepLApiTest extends TestCase
             ),
             array(
                 'detected_source_language' => "EN",
-                'text'                     => "Ein weiterer Text neue Zeile <p>dies ist ein Absatz</p>",
+                'text'                     => "Ein weiterer Text<br>neue Zeile <p>dies ist ein Absatz</p></br> ",
             ),
 
         );

--- a/tests/integration/DeepLApiTest.php
+++ b/tests/integration/DeepLApiTest.php
@@ -313,7 +313,7 @@ class DeepLApiTest extends TestCase
         $deepl        = new DeepL(self::$authKey);
         $englishText  = '<strong>text to do not translate</strong><p>please translate this text</p>';
 
-        self::setExpectedException('\BabyMarkt\DeepL\DeepLException');
+        $this->expectException('\BabyMarkt\DeepL\DeepLException');
 
         $deepl->translate(
             $englishText,

--- a/tests/unit/DeepLTest.php
+++ b/tests/unit/DeepLTest.php
@@ -3,7 +3,7 @@
 namespace BabyMarkt\DeepL\unit;
 
 use BabyMarkt\DeepL\DeepL;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 
 /**
@@ -12,7 +12,7 @@ use ReflectionClass;
  * @package BabyMarkt\DeepL
  * @SuppressWarnings(PHPMD.TooManyPublicMethods)
  */
-class DeepLTest extends PHPUnit_Framework_TestCase
+class DeepLTest extends TestCase
 {
     /**
      * Get protected method
@@ -42,7 +42,7 @@ class DeepLTest extends PHPUnit_Framework_TestCase
         $germanText = 'Hallo Welt';
         $deepl      = new DeepL($authKey);
 
-        $this->setExpectedException('\BabyMarkt\DeepL\DeepLException');
+        $this->expectException('\BabyMarkt\DeepL\DeepLException');
 
         $deepl->translate($germanText);
     }
@@ -58,7 +58,7 @@ class DeepLTest extends PHPUnit_Framework_TestCase
         $buildUrl    = self::getMethod('\BabyMarkt\DeepL\DeepL', 'buildBaseUrl');
         $return      = $buildUrl->invokeArgs($deepl, array());
 
-        $this->assertEquals($expectedUrl, $return);
+        self::assertEquals($expectedUrl, $return);
     }
 
     /**
@@ -73,7 +73,7 @@ class DeepLTest extends PHPUnit_Framework_TestCase
         $buildUrl       = self::getMethod('\BabyMarkt\DeepL\DeepL', 'buildBaseUrl');
         $return         = $buildUrl->invokeArgs($deepl, array());
 
-        $this->assertEquals($expectedString, $return);
+        self::assertEquals($expectedString, $return);
     }
 
 
@@ -103,7 +103,7 @@ class DeepLTest extends PHPUnit_Framework_TestCase
         $buildQuery     = self::getMethod('\BabyMarkt\DeepL\DeepL', 'buildQuery');
         $return         = $buildQuery->invokeArgs($deepl, $args);
 
-        $this->assertEquals($expectedString, $return);
+        self::assertEquals($expectedString, $return);
     }
 
     public function testBuildQueryWithMinimalArguments()
@@ -121,7 +121,7 @@ class DeepLTest extends PHPUnit_Framework_TestCase
         $buildQuery     = self::getMethod('\BabyMarkt\DeepL\DeepL', 'buildQuery');
         $return         = $buildQuery->invokeArgs($deepl, $args);
 
-        $this->assertEquals($expectedString, $return);
+        self::assertEquals($expectedString, $return);
     }
 
     public function testBuildQueryWithEmptyArguments()
@@ -147,7 +147,7 @@ class DeepLTest extends PHPUnit_Framework_TestCase
         $buildQuery     = self::getMethod('\BabyMarkt\DeepL\DeepL', 'buildQuery');
         $return         = $buildQuery->invokeArgs($deepl, $args);
 
-        $this->assertEquals($expectedString, $return);
+        self::assertEquals($expectedString, $return);
     }
 
     public function testBuildQueryWithAllArguments()
@@ -189,7 +189,7 @@ class DeepLTest extends PHPUnit_Framework_TestCase
         $buildQuery = self::getMethod('\BabyMarkt\DeepL\DeepL', 'buildQuery');
         $return     = $buildQuery->invokeArgs($deepl, $args);
 
-        $this->assertEquals($expectation, $return);
+        self::assertEquals($expectation, $return);
     }
 
     public function testBuildQueryWithAllArgumentsAndPreserveFormattingZero()
@@ -228,7 +228,7 @@ class DeepLTest extends PHPUnit_Framework_TestCase
         $buildQuery  = self::getMethod('\BabyMarkt\DeepL\DeepL', 'buildQuery');
         $return      = $buildQuery->invokeArgs($deepl, $args);
 
-        $this->assertEquals($expectation, $return);
+        self::assertEquals($expectation, $return);
     }
 
     public function testBuildQueryWithAllArgumentsAndMultipleTexts()
@@ -269,7 +269,7 @@ class DeepLTest extends PHPUnit_Framework_TestCase
         $buildQuery = self::getMethod('\BabyMarkt\DeepL\DeepL', 'buildQuery');
         $return     = $buildQuery->invokeArgs($deepl, $args);
 
-        $this->assertEquals($expectation, $return);
+        self::assertEquals($expectation, $return);
     }
 
     public function testRemoveEmptyParamsWithMinimalArguments()
@@ -297,7 +297,7 @@ class DeepLTest extends PHPUnit_Framework_TestCase
         $buildQuery     = self::getMethod('\BabyMarkt\DeepL\DeepL', 'removeEmptyParams');
         $return         = $buildQuery->invokeArgs($deepl, $args);
 
-        $this->assertEquals($expectedString, $return);
+        self::assertEquals($expectedString, $return);
     }
 
     public function testRemoveEmptyParamsWithEmptyArguments()
@@ -325,7 +325,7 @@ class DeepLTest extends PHPUnit_Framework_TestCase
         $buildQuery     = self::getMethod('\BabyMarkt\DeepL\DeepL', 'removeEmptyParams');
         $return         = $buildQuery->invokeArgs($deepl, $args);
 
-        $this->assertEquals($expectedString, $return);
+        self::assertEquals($expectedString, $return);
     }
 
     public function testRemoveEmptyParamsAllArgumentsAndPreserveFormattingZero()
@@ -361,7 +361,7 @@ class DeepLTest extends PHPUnit_Framework_TestCase
         $buildQuery     = self::getMethod('\BabyMarkt\DeepL\DeepL', 'removeEmptyParams');
         $return         = $buildQuery->invokeArgs($deepl, $args);
 
-        $this->assertSame($expectation, $return);
+        self::assertSame($expectation, $return);
     }
 
     public function testRemoveEmptyParamsWithAllArguments()
@@ -399,7 +399,7 @@ class DeepLTest extends PHPUnit_Framework_TestCase
         $buildQuery     = self::getMethod('\BabyMarkt\DeepL\DeepL', 'removeEmptyParams');
         $return         = $buildQuery->invokeArgs($deepl, $args);
 
-        $this->assertEquals($expectation, $return);
+        self::assertEquals($expectation, $return);
     }
 
     public function testRemoveEmptyParamsAllArgumentsAndOutlineDetectionOne()
@@ -434,7 +434,7 @@ class DeepLTest extends PHPUnit_Framework_TestCase
         $buildQuery     = self::getMethod('\BabyMarkt\DeepL\DeepL', 'removeEmptyParams');
         $return         = $buildQuery->invokeArgs($deepl, $args);
 
-        $this->assertEquals($expectation, $return);
+        self::assertEquals($expectation, $return);
     }
 
     /**
@@ -446,7 +446,7 @@ class DeepLTest extends PHPUnit_Framework_TestCase
         $germanText = 'Hallo Welt';
         $deepl      = new DeepL($authKey);
 
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
 
         $deepl->translate($germanText, 'de', 'en', array('xml'));
     }


### PR DESCRIPTION
- Dropped support for old PHP Versions and fixed incompatibilities with PHP 8.0
- Supported versions align with the version support given by PHPUnit That's a reasonable denominator I guess.
- Removed a tests which expects an exception based on an error thrown in previous test runs against DeepL. 