### PR TITLE
Fix CI pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,14 +13,15 @@ matrix:
     - php: 7.1
     - php: 7.2
     - php: 7.3
-    - php: 7.4snapshot
+      dist: precise
+    - php: 7.4
+      dist: trusty
     - php: nightly
   allow_failures:
     - php: nightly
 
 env:
   - COMPOSER_ALLOW_XDEBUG=0
-  - XDEBUG_MODE=coverage
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ matrix:
 
 env:
   - COMPOSER_ALLOW_XDEBUG=0
+  - XDEBUG_MODE=coverage
 
 cache:
   directories:


### PR DESCRIPTION
Apparently Travis deployed Xdebug 3, which breaks on older versions of PHPUnit (https://github.com/sebastianbergmann/php-code-coverage/issues/834).

It's probably not ideal but the easiest solution I found is to force on older versions of Ubuntu on which Xebug3 is not installed. This seems to work for now.