### PR TITLE
Add glossary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 composer.lock
 phpunit.xml
 
+/.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,22 +2,7 @@ language: php
 
 matrix:
   include:
-    - php: 5.3
-      dist: precise
-    - php: 5.4
-      dist: precise
-    - php: 5.5
-      dist: precise
-    - php: 5.6
-    - php: 7.0
-    - php: 7.1
-    - php: 7.2
-    - php: 7.3
-    - php: 7.4snapshot
-    - php: nightly
     - php: 8.0
-  allow_failures:
-    - php: nightly
 
 env:
   - COMPOSER_ALLOW_XDEBUG=0

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ matrix:
     - php: 7.3
     - php: 7.4snapshot
     - php: nightly
+    - php: 8.0
   allow_failures:
     - php: nightly
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 Simple PHP Library for DeepL API. You can translate one or multiple text strings (up to 50) per request.
 
-🇩🇪🇬🇧🇺🇸🇪🇸🇲🇽🇫🇷🇮🇹🇯🇵🇳🇱🇵🇱🇵🇹🇧🇷🇷🇺🇨🇳
+🇩🇪🇦🇹🇨🇭🇬🇧🇺🇸🇪🇸🇲🇽🇫🇷🇮🇹🇯🇵🇳🇱🇵🇱🇵🇹🇧🇷🇷🇺🇨🇳🇬🇷🇩🇰🇨🇿🇪🇪🇫🇮🇭🇺🇱🇹🇱🇻🇷🇴🇷🇸🇸🇰🇸🇪
 
 [Official DeepL API][link-deepl]
 
@@ -30,6 +30,12 @@ Create an instance with your auth key:
 ```php
 $authKey = '<AUTH KEY>';
 $deepl   = new DeepL($authKey);
+```
+
+Use the DeepL API Pro:
+```php
+$authKey = '<AUTH KEY>';
+$deepl   = new DeepL($authKey,2,'api.deepl.com');
 ```
 
 ### Translate
@@ -99,12 +105,73 @@ foreach ($targetLanguagesArray as $targetLanguage) {
 }
 ```
 ### Monitoring usage
-You can now check ow much you translate, as well as the limit:
+You can now check how much you translate, as well as the limit:
 ```php
 $usageArray = $deepl->usage();
 
 echo 'You have used '.$usageArray['character_count'].' of '.$usageArray['character_limit'].' in the current billing period.'.PHP_EOL;
  
+```
+
+### Glossary
+Create a glossary
+```php
+$glossary = $deepl->createGlossary('MyGlossary', ['Hallo' => 'Hello'], 'de', 'en');
+```
+
+| param               | Description                                                                                                                                                                                                                                                                                                                                                                                                               |
+|---------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| $name               | Glossary name
+| $entries            | Array of entries
+| $sourceLanguage     | The source language into which the glossary rule apply                                                                                                                                                                                                                                                                                                                                                                    |
+| $targetLanguage     | The target language into which the glossary rule apply                                                                                                                                                                                                                                                                                                                                             |
+
+Delete a glossary
+```php
+$glossary = $deepl->deleteGlossary($glossaryId);
+```
+
+| param               | Description                                                                                                                                                                                                                                                                                                                                                                                                               |
+|---------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| $glossaryId         | Glossary uuid (set by DeepL when glossary is created)
+
+List glossaries
+```php
+$glossaries = $deepl->listGlossaries();
+foreach ($glossaries as $glossary) {
+    var_dump($glossary);
+}
+```
+
+Get glossary meta information: creation date, is glossary ready to use ...
+```php
+$glossaryInformation = $deepl->glossaryInformation($glossaryId);
+var_dump($glossaryInformation);
+```
+
+| param               | Description                                                                                                                                                                                                                                                                                                                                                                                                               |
+|---------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| $glossaryId         | Glossary uuid (set by DeepL when glossary is created)
+
+Get glossary entries
+```php
+$entries = $deepl->glossaryEntries($glossaryId);
+foreach ($entries as $sourceLangText => $targetLangText) {
+    echo $sourceLangText .' > '.$targetLangText;
+}
+```
+
+| param               | Description                                                                                                                                                                                                                                                                                                                                                                                                               |
+|---------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| $glossaryId         | Glossary uuid (set by DeepL when glossary is created)
+
+### Configuring cURL requests
+If you need to use a proxy, you can configure the underlying curl client to use one. You can also specify a timeout to avoid waiting for several minutes if Deepl is unreachable
+```php
+$deepl->setTimeout(10); //give up after 10 seconds
+$deepl->setProxy('http://corporate-proxy.com:3128');
+$deepl->setProxyCredentials('username:password');
+
 ```
 ## Testing
 
@@ -149,7 +216,7 @@ The MIT License (MIT). Please see [License File](LICENSE.md) for more informatio
 [ico-downloads]: https://img.shields.io/packagist/dt/babymarkt/deepl-php-lib.svg?style=flat-square
 
 [link-packagist]: https://packagist.org/packages/babymarkt/deepl-php-lib
-[link-travis]: https://travis-ci.org/Baby-Markt/deepl-php-lib
+[link-travis]: https://travis-ci.com/Baby-Markt/deepl-php-lib
 [link-scrutinizer]: https://scrutinizer-ci.com/g/Baby-Markt/deepl-php-lib/code-structure
 [link-code-quality]: https://scrutinizer-ci.com/g/Baby-Markt/deepl-php-lib
 [link-downloads]: https://packagist.org/packages/babymarkt/deepl-php-lib

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "babymarkt/deepl-php-lib",
     "type": "library",
-    "description": "DeepL API Client Library supporting PHP >= 5.3 && PHP < 8.0",
+    "description": "DeepL API Client Library supporting PHP >= 5.3",
     "keywords": [
       "babymarkt",
       "deepl",
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3 <8.0",
+        "php": ">=5.3",
         "ext-json": "*",
         "ext-curl": "*"
     },

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "require-dev": {
         "phpmd/phpmd": "2.4.*",
-        "phpunit/phpunit": "^4.8",
+        "phpunit/phpunit": "^9.5",
         "squizlabs/php_codesniffer": "^3.5"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "babymarkt/deepl-php-lib",
     "type": "library",
-    "description": "DeepL API Client Library supporting PHP >= 5.3",
+    "description": "DeepL API Client Library supporting PHP >= 8.0",
     "keywords": [
       "babymarkt",
       "deepl",
@@ -19,12 +19,12 @@
         }
     ],
     "require": {
-        "php": ">=5.3",
+        "php": ">=8.0",
         "ext-json": "*",
         "ext-curl": "*"
     },
     "require-dev": {
-        "phpmd/phpmd": "2.4.*",
+        "phpmd/phpmd": "^2.9",
         "phpunit/phpunit": "^9.5",
         "squizlabs/php_codesniffer": "^3.5"
     },

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "require-dev": {
         "phpmd/phpmd": "2.4.*",
         "phpunit/phpunit": "^4.8",
-        "squizlabs/php_codesniffer": "^2.9"
+        "squizlabs/php_codesniffer": "^3.5"
     },
     "autoload": {
         "psr-4": {

--- a/src/DeepL.php
+++ b/src/DeepL.php
@@ -28,40 +28,32 @@ class DeepL
 
     /**
      * DeepL API Version (v2 is default since 2018)
-     *
-     * @var integer
      */
-    protected $apiVersion;
+    protected int $apiVersion;
 
     /**
      * DeepL API Auth Key (DeepL Pro access required)
-     *
-     * @var string
      */
-    protected $authKey;
+    protected string $authKey;
 
     /**
      * cURL resource
-     *
-     * @var resource
      */
     protected $curl;
 
     /**
      * Hostname of the API (in most cases api.deepl.com)
-     *
-     * @var string
      */
-    protected $host;
+    protected string $host;
 
     /**
      * DeepL constructor
      *
-     * @param string  $authKey
+     * @param string $authKey
      * @param integer $apiVersion
-     * @param string  $host
+     * @param string $host
      */
-    public function __construct($authKey, $apiVersion = 2, $host = 'api.deepl.com')
+    public function __construct(string $authKey, $apiVersion = 2, $host = 'api.deepl.com')
     {
         $this->authKey    = $authKey;
         $this->apiVersion = $apiVersion;
@@ -84,7 +76,7 @@ class DeepL
     /**
      * Call languages-Endpoint and return Json-response as an Array
      *
-     * @param string $type
+     * @param null $type
      *
      * @return array
      * @throws DeepLException
@@ -93,9 +85,8 @@ class DeepL
     {
         $url       = $this->buildBaseUrl(self::API_URL_RESOURCE_LANGUAGES);
         $body      = $this->buildQuery(array('type' => $type));
-        $languages = $this->request($url, $body);
 
-        return $languages;
+        return $this->request($url, $body);
     }
 
     /**
@@ -103,24 +94,23 @@ class DeepL
      * For detailed info on Parameters see README.md
      *
      * @param string|string[] $text
-     * @param string          $sourceLang
-     * @param string          $targetLang
-     * @param string          $tagHandling
-     * @param array|null      $ignoreTags
-     * @param string          $formality
-     * @param null            $splitSentences
-     * @param null            $preserveFormatting
-     * @param array|null      $nonSplittingTags
-     * @param null            $outlineDetection
-     * @param array|null      $splittingTags
+     * @param string $sourceLang
+     * @param string $targetLang
+     * @param null $tagHandling
+     * @param array|null $ignoreTags
+     * @param string $formality
+     * @param null $splitSentences
+     * @param null $preserveFormatting
+     * @param array|null $nonSplittingTags
+     * @param null $outlineDetection
+     * @param array|null $splittingTags
      *
      * @return array
      * @throws DeepLException
-     *
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
     public function translate(
-        $text,
+        string|array $text,
         $sourceLang = 'de',
         $targetLang = 'en',
         $tagHandling = null,
@@ -168,9 +158,8 @@ class DeepL
     public function usage()
     {
         $url   = $this->buildBaseUrl(self::API_URL_RESOURCE_USAGE);
-        $usage = $this->request($url);
 
-        return $usage;
+        return $this->request($url);
     }
 
 
@@ -183,7 +172,7 @@ class DeepL
      */
     protected function buildBaseUrl($resource = 'translate')
     {
-        $url = sprintf(
+        return sprintf(
             self::API_URL_BASE,
             self::API_URL_SCHEMA,
             $this->host,
@@ -191,8 +180,6 @@ class DeepL
             $resource,
             $this->authKey
         );
-
-        return $url;
     }
 
     /**
@@ -200,7 +187,7 @@ class DeepL
      *
      * @return string
      */
-    protected function buildQuery($paramsArray)
+    protected function buildQuery(array $paramsArray)
     {
         if (isset($paramsArray['text']) && true === is_array($paramsArray['text'])) {
             $text = $paramsArray['text'];
@@ -227,8 +214,6 @@ class DeepL
     }
 
 
-
-
     /**
      * Make a request to the given URL
      *
@@ -239,7 +224,7 @@ class DeepL
      *
      * @throws DeepLException
      */
-    protected function request($url, $body = '')
+    protected function request(string $url, $body = '')
     {
         curl_setopt($this->curl, CURLOPT_POST, true);
         curl_setopt($this->curl, CURLOPT_URL, $url);
@@ -270,7 +255,7 @@ class DeepL
      *
      * @return array
      */
-    private function removeEmptyParams($paramsArray)
+    private function removeEmptyParams(array $paramsArray)
     {
 
         foreach ($paramsArray as $key => $value) {

--- a/src/DeepL.php
+++ b/src/DeepL.php
@@ -2,6 +2,8 @@
 
 namespace BabyMarkt\DeepL;
 
+use InvalidArgumentException;
+
 /**
  * DeepL API client library
  *
@@ -10,11 +12,18 @@ namespace BabyMarkt\DeepL;
 class DeepL
 {
     const API_URL_SCHEMA = 'https';
+
     /**
      * API BASE URL
      * https://api.deepl.com/v2/[resource]?auth_key=[yourAuthKey]
      */
     const API_URL_BASE = '%s://%s/v%s/%s?auth_key=%s';
+
+    /**
+     * API BASE URL without authentication query parameter
+     * https://api.deepl.com/v2/[resource]
+     */
+    const API_URL_BASE_NO_AUTH = '%s://%s/v%s/%s';
 
     /**
      * API URL: usage
@@ -27,33 +36,67 @@ class DeepL
     const API_URL_RESOURCE_LANGUAGES = 'languages';
 
     /**
-     * DeepL API Version (v2 is default since 2018)
+     * API URL: glossaries
      */
-    protected int $apiVersion;
+    const API_URL_RESOURCE_GLOSSARIES = 'glossaries';
+
+    /**
+     * DeepL API Version (v2 is default since 2018)
+     *
+     * @var integer
+     */
+    protected $apiVersion;
 
     /**
      * DeepL API Auth Key (DeepL Pro access required)
+     *
+     * @var string
      */
-    protected string $authKey;
+    protected $authKey;
 
     /**
      * cURL resource
+     *
+     * @var resource
      */
     protected $curl;
 
     /**
      * Hostname of the API (in most cases api.deepl.com)
+     *
+     * @var string
      */
-    protected string $host;
+    protected $host;
+
+    /**
+     * URL of the proxy used to connect to DeepL (if needed)
+     *
+     * @var string|null
+     */
+    protected $proxy = null;
+
+    /**
+     * Credentials for the proxy used to connect to DeepL (username:password)
+     *
+     * @var string|null
+     */
+    protected $proxyCredentials = null;
+
+    /**
+     * Maximum number of seconds the query should take
+     *
+     * @var int|null
+     */
+    protected $timeout = null;
 
     /**
      * DeepL constructor
      *
-     * @param string $authKey
+     * @param string  $authKey
      * @param integer $apiVersion
-     * @param string $host
+     * @param string  $host
      */
-    public function __construct(string $authKey, $apiVersion = 2, $host = 'api.deepl.com')
+    public function __construct($authKey, $apiVersion = 2, $host = 'api.deepl.com')
     {
         $this->authKey    = $authKey;
         $this->apiVersion = $apiVersion;
@@ -76,7 +119,7 @@ class DeepL
     /**
      * Call languages-Endpoint and return Json-response as an Array
      *
-     * @param null $type
+     * @param string $type
      *
      * @return array
      * @throws DeepLException
@@ -85,8 +128,40 @@ class DeepL
     {
         $url       = $this->buildBaseUrl(self::API_URL_RESOURCE_LANGUAGES);
         $body      = $this->buildQuery(array('type' => $type));
+        $languages = $this->request($url, $body);
 
-        return $this->request($url, $body);
+        return $languages;
+    }
+
+    /**
+     * Set a proxy to use for querying the DeepL API if needed
+     *
+     * @param string $proxy Proxy URL (e.g 'http://proxy-domain.com:3128')
+     */
+    public function setProxy($proxy)
+    {
+
+        $this->proxy = $proxy;
+    }
+
+    /**
+     * Set the proxy credentials
+     *
+     * @param string $proxyCredentials proxy credentials (using 'username:password' format)
+     */
+    public function setProxyCredentials($proxyCredentials)
+    {
+        $this->proxyCredentials = $proxyCredentials;
+    }
+
+    /**
+     * Set a timeout for queries to the DeepL API
+     *
+     * @param int $timeout Timeout in seconds
+     */
+    public function setTimeout($timeout)
+    {
+        $this->timeout = $timeout;
     }
 
     /**
@@ -94,23 +169,24 @@ class DeepL
      * For detailed info on Parameters see README.md
      *
      * @param string|string[] $text
-     * @param string $sourceLang
-     * @param string $targetLang
-     * @param null $tagHandling
-     * @param array|null $ignoreTags
-     * @param string $formality
-     * @param null $splitSentences
-     * @param null $preserveFormatting
-     * @param array|null $nonSplittingTags
-     * @param null $outlineDetection
-     * @param array|null $splittingTags
+     * @param string          $sourceLang
+     * @param string          $targetLang
+     * @param string          $tagHandling
+     * @param array|null      $ignoreTags
+     * @param string          $formality
+     * @param null            $splitSentences
+     * @param null            $preserveFormatting
+     * @param array|null      $nonSplittingTags
+     * @param null            $outlineDetection
+     * @param array|null      $splittingTags
      *
      * @return array
      * @throws DeepLException
+     *
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
     public function translate(
-        string|array $text,
+        $text,
         $sourceLang = 'de',
         $targetLang = 'en',
         $tagHandling = null,
@@ -123,7 +199,7 @@ class DeepL
         array $splittingTags = null
     ) {
         if (is_array($tagHandling)) {
-            throw new \InvalidArgumentException('$tagHandling must be of type String in V2 of DeepLLibrary');
+            throw new InvalidArgumentException('$tagHandling must be of type String in V2 of DeepLLibrary');
         }
         $paramsArray = array(
             'text'                => $text,
@@ -158,10 +234,116 @@ class DeepL
     public function usage()
     {
         $url   = $this->buildBaseUrl(self::API_URL_RESOURCE_USAGE);
+        $usage = $this->request($url);
 
-        return $this->request($url);
+        return $usage;
     }
 
+    /**
+     * Calls the glossary-Endpoint and return Json-response as an array
+     *
+     * @return array
+     * @throws DeepLException
+     */
+    public function listGlossaries()
+    {
+        return $this->request($this->buildBaseUrl(self::API_URL_RESOURCE_GLOSSARIES), '', 'GET');
+    }
+
+    /**
+     * Creates a glossary, entries must be formatted as [sourceText => entryText] e.g: ['Hallo' => 'Hello']
+     *
+     * @param string $name
+     * @param array $entries
+     * @param string $sourceLang
+     * @param string $targetLang
+     * @param string $entriesFormat
+     * @return array|null
+     * @throws DeepLException
+     */
+    public function createGlossary(
+        string $name,
+        array $entries,
+        string $sourceLang = 'de',
+        string $targetLang = 'en',
+        string $entriesFormat = 'tsv'
+    ) {
+        $formattedEntries = "";
+        foreach ($entries as $source => $target) {
+            $formattedEntries .= sprintf("%s\t%s\n", $source, $target);
+        }
+
+        $paramsArray = [
+            'name' => $name,
+            'source_lang'    => $sourceLang,
+            'target_lang'    => $targetLang,
+            'entries'        => $formattedEntries,
+            'entries_format' => $entriesFormat
+        ];
+
+        $url  = $this->buildBaseUrl(self::API_URL_RESOURCE_GLOSSARIES, false);
+        $body = $this->buildQuery($paramsArray);
+
+        return $this->request($url, $body);
+    }
+
+    /**
+     * Deletes a glossary
+     *
+     * @param string $glossaryId
+     * @return array|null
+     * @throws DeepLException
+     */
+    public function deleteGlossary(string $glossaryId)
+    {
+        $url = $this->buildBaseUrl(self::API_URL_RESOURCE_GLOSSARIES, false);
+        $url .= "/$glossaryId";
+
+        return $this->request($url, '', 'DELETE');
+    }
+
+    /**
+     * Gets information about a glossary
+     *
+     * @param string $glossaryId
+     * @return array|null
+     * @throws DeepLException
+     */
+    public function glossaryInformation(string $glossaryId)
+    {
+        $url  = $this->buildBaseUrl(self::API_URL_RESOURCE_GLOSSARIES, false);
+        $url .= "/$glossaryId";
+
+        return $this->request($url, '', 'GET');
+    }
+
+    /**
+     * Fetch glossary entries and format them as associative array [source => target]
+     *
+     * @param string $glossaryId
+     * @return array
+     * @throws DeepLException
+     */
+    public function glossaryEntries(string $glossaryId)
+    {
+        $url = $this->buildBaseUrl(self::API_URL_RESOURCE_GLOSSARIES, false);
+        $url .= "/$glossaryId/entries";
+
+        $response = $this->request($url, '', 'GET');
+
+        $entries = [];
+        if (!empty($response)) {
+            $allEntries = preg_split('/\n/', $response);
+            foreach ($allEntries as $entry) {
+                $sourceAndTarget = preg_split('/\s+/', rtrim($entry));
+                if (isset($sourceAndTarget[0], $sourceAndTarget[1])) {
+                    $entries[$sourceAndTarget[0]] = $sourceAndTarget[1];
+                }
+            }
+        }
+
+        return $entries;
+    }
 
     /**
      * Creates the Base-Url which all of the 3 API-resources have in common.
@@ -170,15 +352,25 @@ class DeepL
      *
      * @return string
      */
-    protected function buildBaseUrl($resource = 'translate')
+    protected function buildBaseUrl($resource = 'translate', $withAuth = true)
     {
+        if ($withAuth) {
+            return sprintf(
+                self::API_URL_BASE,
+                self::API_URL_SCHEMA,
+                $this->host,
+                $this->apiVersion,
+                $resource,
+                $this->authKey
+            );
+        }
+
         return sprintf(
-            self::API_URL_BASE,
+            self::API_URL_BASE_NO_AUTH,
             self::API_URL_SCHEMA,
             $this->host,
             $this->apiVersion,
-            $resource,
-            $this->authKey
+            $resource
         );
     }
 
@@ -187,7 +379,7 @@ class DeepL
      *
      * @return string
      */
-    protected function buildQuery(array $paramsArray)
+    protected function buildQuery($paramsArray)
     {
         if (isset($paramsArray['text']) && true === is_array($paramsArray['text'])) {
             $text = $paramsArray['text'];
@@ -213,37 +405,81 @@ class DeepL
         return $body;
     }
 
-
     /**
      * Make a request to the given URL
      *
      * @param string $url
      * @param string $body
+     * @param string $method
      *
      * @return array
      *
      * @throws DeepLException
      */
-    protected function request(string $url, $body = '')
+    protected function request($url, $body = '', $method = 'POST')
     {
-        curl_setopt($this->curl, CURLOPT_POST, true);
+        switch ($method) {
+            case 'DELETE':
+                curl_setopt($this->curl, CURLOPT_CUSTOMREQUEST, 'DELETE');
+                break;
+            case 'POST':
+                curl_setopt($this->curl, CURLOPT_POST, true);
+                break;
+            default:
+                break;
+        }
+
         curl_setopt($this->curl, CURLOPT_URL, $url);
-        curl_setopt($this->curl, CURLOPT_POSTFIELDS, $body);
+
+        if ($method === 'POST') {
+            curl_setopt($this->curl, CURLOPT_POSTFIELDS, $body);
+        }
+
         curl_setopt($this->curl, CURLOPT_HTTPHEADER, array('Content-Type: application/x-www-form-urlencoded'));
+        curl_setopt($this->curl, CURLOPT_HTTPHEADER, array("Authorization: DeepL-Auth-Key $this->authKey"));
+
+        if ($this->proxy !== null) {
+            curl_setopt($this->curl, CURLOPT_PROXY, $this->proxy);
+        }
+
+        if ($this->proxyCredentials !== null) {
+            curl_setopt($this->curl, CURLOPT_PROXYAUTH, $this->proxyCredentials);
+        }
+
+        if ($this->timeout !== null) {
+            curl_setopt($this->curl, CURLOPT_TIMEOUT, $this->timeout);
+        }
 
         $response = curl_exec($this->curl);
 
         if (curl_errno($this->curl)) {
-            throw new DeepLException('There was a cURL Request Error.');
+            throw new DeepLException('There was a cURL Request Error : ' . curl_error($this->curl));
         }
-        $httpCode      = curl_getinfo($this->curl, CURLINFO_HTTP_CODE);
-        $responseArray = json_decode($response, true);
+        $httpCode = curl_getinfo($this->curl, CURLINFO_HTTP_CODE);
 
-        if ($httpCode != 200 && is_array($responseArray) && array_key_exists('message', $responseArray)) {
+        return $this->handleResponse($response, $httpCode);
+    }
+
+    /**
+     * Handles the different kind of response returned from API, array, string or null
+     *
+     * @param $response
+     * @param $httpCode
+     * @return array|mixed|null
+     * @throws DeepLException
+     */
+    private function handleResponse($response, $httpCode)
+    {
+        $responseArray = json_decode($response, true);
+        if (($httpCode === 200 || $httpCode === 204) && is_null($responseArray)) {
+            return empty($response) ? null : $response;
+        }
+
+        if ($httpCode !== 200 && is_array($responseArray) && array_key_exists('message', $responseArray)) {
             throw new DeepLException($responseArray['message'], $httpCode);
         }
 
-        if (false === is_array($responseArray)) {
+        if (!is_array($responseArray)) {
             throw new DeepLException('The Response seems to not be valid JSON.', $httpCode);
         }
 
@@ -255,9 +491,8 @@ class DeepL
      *
      * @return array
      */
-    private function removeEmptyParams(array $paramsArray)
+    private function removeEmptyParams($paramsArray)
     {
-
         foreach ($paramsArray as $key => $value) {
             if (true === empty($value)) {
                 unset($paramsArray[$key]);

--- a/tests/integration/DeepLApiTest.php
+++ b/tests/integration/DeepLApiTest.php
@@ -7,6 +7,8 @@ use BabyMarkt\DeepL\DeepLException;
 use PHPUnit\Framework\TestCase;
 use PHPUnit_Framework_TestCase;
 use ReflectionClass;
+use ReflectionException;
+use ReflectionMethod;
 
 /**
  * Class DeepLTest
@@ -21,7 +23,7 @@ class DeepLApiTest extends TestCase
      *
      * @var bool|string
      */
-    protected static bool|string $authKey = false;
+    protected static array|bool|string $authKey = false;
 
     /**
      * Setup DeepL Auth Key.
@@ -45,9 +47,9 @@ class DeepLApiTest extends TestCase
      * @param $className
      * @param $methodName
      *
-     * @throws \ReflectionException
+     * @throws ReflectionException
      *
-     * @return \ReflectionMethod
+     * @return ReflectionMethod
      */
     protected static function getMethod($className, $methodName)
     {

--- a/tests/integration/DeepLApiTest.php
+++ b/tests/integration/DeepLApiTest.php
@@ -3,6 +3,8 @@
 namespace BabyMarkt\DeepL\integration;
 
 use BabyMarkt\DeepL\DeepL;
+use BabyMarkt\DeepL\DeepLException;
+use PHPUnit\Framework\TestCase;
 use PHPUnit_Framework_TestCase;
 use ReflectionClass;
 
@@ -12,19 +14,19 @@ use ReflectionClass;
  * @package BabyMarkt\DeepL
  * @SuppressWarnings(PHPMD.TooManyPublicMethods)
  */
-class DeepLApiTest extends PHPUnit_Framework_TestCase
+class DeepLApiTest extends TestCase
 {
     /**
      * DeepL Auth Key.
      *
      * @var bool|string
      */
-    protected static $authKey = false;
+    protected static bool|string $authKey = false;
 
     /**
      * Setup DeepL Auth Key.
      */
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
 
@@ -58,6 +60,7 @@ class DeepLApiTest extends PHPUnit_Framework_TestCase
 
     /**
      * Test translate() success with v2 API
+     * @throws DeepLException
      */
     public function testTranslateSuccess()
     {
@@ -77,6 +80,7 @@ class DeepLApiTest extends PHPUnit_Framework_TestCase
 
     /**
      * Test translate() success with v1 API
+     * @throws DeepLException
      */
     public function testTranslateV1Success()
     {
@@ -105,7 +109,7 @@ class DeepLApiTest extends PHPUnit_Framework_TestCase
         $germanText = 'Hallo Welt';
         $deepl      = new DeepL(self::$authKey, 3);
 
-        $this->setExpectedException('\BabyMarkt\DeepL\DeepLException');
+        $this->expectException('\BabyMarkt\DeepL\DeepLException');
 
         $deepl->translate($germanText);
     }
@@ -240,13 +244,14 @@ class DeepLApiTest extends PHPUnit_Framework_TestCase
 
         $deepl    = new DeepL(self::$authKey);
 
-        $this->setExpectedException('\BabyMarkt\DeepL\DeepLException');
+        $this->expectException('\BabyMarkt\DeepL\DeepLException');
 
         $deepl->languages('fail');
     }
 
     /**
      * Test translate() with all Params
+     * @throws DeepLException
      */
     public function testTranslateWithAllParams()
     {
@@ -278,6 +283,7 @@ class DeepLApiTest extends PHPUnit_Framework_TestCase
 
     /**
      * Test translate() $formality
+     * @throws DeepLException
      */
     public function testTranslateFormality()
     {
@@ -313,7 +319,7 @@ class DeepLApiTest extends PHPUnit_Framework_TestCase
         $deepl        = new DeepL(self::$authKey);
         $englishText  = '<strong>text to do not translate</strong><p>please translate this text</p>';
 
-        $this->setExpectedException('\BabyMarkt\DeepL\DeepLException');
+        $this->expectException('\BabyMarkt\DeepL\DeepLException');
 
         $deepl->translate(
             $englishText,
@@ -328,6 +334,7 @@ class DeepLApiTest extends PHPUnit_Framework_TestCase
 
     /**
      * Test to Test the Tag-Handling.
+     * @throws DeepLException
      */
     public function testTranslateWithHTML()
     {
@@ -381,7 +388,7 @@ class DeepLApiTest extends PHPUnit_Framework_TestCase
 
         $deepl = new DeepL(self::$authKey);
 
-        $this->setExpectedException('\BabyMarkt\DeepL\DeepLException');
+        $this->expectException('\BabyMarkt\DeepL\DeepLException');
         $deepl->translate('some txt', 'dk', 'de');
     }
 
@@ -396,7 +403,7 @@ class DeepLApiTest extends PHPUnit_Framework_TestCase
 
         $deepl = new DeepL(self::$authKey);
 
-        $this->setExpectedException('\BabyMarkt\DeepL\DeepLException');
+        $this->expectException('\BabyMarkt\DeepL\DeepLException');
         $deepl->translate('some txt', 'en', 'dk');
     }
 }

--- a/tests/integration/DeepLApiTest.php
+++ b/tests/integration/DeepLApiTest.php
@@ -3,12 +3,8 @@
 namespace BabyMarkt\DeepL\integration;
 
 use BabyMarkt\DeepL\DeepL;
-use BabyMarkt\DeepL\DeepLException;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_TestCase;
 use ReflectionClass;
-use ReflectionException;
-use ReflectionMethod;
 
 /**
  * Class DeepLTest
@@ -23,7 +19,19 @@ class DeepLApiTest extends TestCase
      *
      * @var bool|string
      */
-    protected static array|bool|string $authKey = false;
+    protected static $authKey = '';
+
+    /**
+     * Proxy URL
+     * @var bool|string
+     */
+    private static $proxy;
+
+    /**
+     * Proxy Credentials
+     * @var bool|string
+     */
+    private static $proxyCredentials;
 
     /**
      * Setup DeepL Auth Key.
@@ -33,12 +41,16 @@ class DeepLApiTest extends TestCase
         parent::setUpBeforeClass();
 
         $authKey = getenv('DEEPL_AUTH_KEY');
+        $proxy = getenv('HTTP_PROXY');
+        $proxyCredentials = getenv('HTTP_PROXY_CREDENTIALS');
 
         if ($authKey === false) {
             return;
         }
 
         self::$authKey = $authKey;
+        self::$proxy = $proxy;
+        self::$proxyCredentials = $proxyCredentials;
     }
 
     /**
@@ -47,9 +59,9 @@ class DeepLApiTest extends TestCase
      * @param $className
      * @param $methodName
      *
-     * @throws ReflectionException
+     * @throws \ReflectionException
      *
-     * @return ReflectionMethod
+     * @return \ReflectionMethod
      */
     protected static function getMethod($className, $methodName)
     {
@@ -62,42 +74,40 @@ class DeepLApiTest extends TestCase
 
     /**
      * Test translate() success with v2 API
-     * @throws DeepLException
      */
     public function testTranslateSuccess()
     {
         if (self::$authKey === false) {
-            $this->markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
+            self::markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
         }
 
         $deepl = new DeepL(self::$authKey);
 
         $germanText     = 'Hallo Welt';
-        $expectedText   = 'Hello World';
+        $expectedText   = 'Hello world';
 
         $translatedText = $deepl->translate($germanText);
 
-        $this->assertEquals($expectedText, $translatedText[0]['text']);
+        self::assertEquals($expectedText, $translatedText[0]['text']);
     }
 
     /**
      * Test translate() success with v1 API
-     * @throws DeepLException
      */
     public function testTranslateV1Success()
     {
         if (self::$authKey === false) {
-            $this->markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
+            self::markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
         }
 
         $deepl = new DeepL(self::$authKey, 1);
 
         $germanText     = 'Hallo Welt';
-        $expectedText   = 'Hello World';
+        $expectedText   = 'Hello world';
 
         $translatedText = $deepl->translate($germanText);
 
-        $this->assertEquals($expectedText, $translatedText[0]['text']);
+        self::assertEquals($expectedText, $translatedText[0]['text']);
     }
 
     /**
@@ -106,7 +116,7 @@ class DeepLApiTest extends TestCase
     public function testTranslateWrongVersion()
     {
         if (self::$authKey === false) {
-            $this->markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
+            self::markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
         }
         $germanText = 'Hallo Welt';
         $deepl      = new DeepL(self::$authKey, 3);
@@ -122,7 +132,7 @@ class DeepLApiTest extends TestCase
     public function testTranslateTagHandlingSuccess()
     {
         if (self::$authKey === false) {
-            $this->markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
+            self::markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
         }
 
         $deepl = new DeepL(self::$authKey);
@@ -137,7 +147,7 @@ class DeepLApiTest extends TestCase
             'xml'
         );
 
-        $this->assertEquals($expectedText, $translatedText[0]['text']);
+        self::assertEquals($expectedText, $translatedText[0]['text']);
     }
 
     /**
@@ -146,7 +156,7 @@ class DeepLApiTest extends TestCase
     public function testTranslateIgnoreTagsSuccess()
     {
         if (self::$authKey === false) {
-            $this->markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
+            self::markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
         }
 
         $deepl = new DeepL(self::$authKey);
@@ -162,7 +172,7 @@ class DeepLApiTest extends TestCase
             array('strong')
         );
 
-        $this->assertEquals($expectedText, $translatedText[0]['text']);
+        self::assertEquals($expectedText, $translatedText[0]['text']);
     }
 
     /**
@@ -171,14 +181,14 @@ class DeepLApiTest extends TestCase
     public function testUsage()
     {
         if (self::$authKey === false) {
-            $this->markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
+            self::markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
         }
 
         $deepl    = new DeepL(self::$authKey);
         $response = $deepl->usage();
 
-        $this->assertArrayHasKey('character_count', $response);
-        $this->assertArrayHasKey('character_limit', $response);
+        self::assertArrayHasKey('character_count', $response);
+        self::assertArrayHasKey('character_limit', $response);
     }
 
     /**
@@ -187,15 +197,15 @@ class DeepLApiTest extends TestCase
     public function testLanguages()
     {
         if (self::$authKey === false) {
-            $this->markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
+            self::markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
         }
 
         $deepl    = new DeepL(self::$authKey);
         $response = $deepl->languages();
 
         foreach ($response as $language) {
-            $this->assertArrayHasKey('language', $language);
-            $this->assertArrayHasKey('name', $language);
+            self::assertArrayHasKey('language', $language);
+            self::assertArrayHasKey('name', $language);
         }
     }
 
@@ -205,33 +215,33 @@ class DeepLApiTest extends TestCase
     public function testLanguagesSource()
     {
         if (self::$authKey === false) {
-            $this->markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
+            self::markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
         }
 
         $deepl    = new DeepL(self::$authKey);
         $response = $deepl->languages('source');
 
         foreach ($response as $language) {
-            $this->assertArrayHasKey('language', $language);
-            $this->assertArrayHasKey('name', $language);
+            self::assertArrayHasKey('language', $language);
+            self::assertArrayHasKey('name', $language);
         }
     }
 
     /**
-     * Test languages()  can return the targe-languages
+     * Test languages()  can return the target-languages
      */
     public function testLanguagesTarget()
     {
         if (self::$authKey === false) {
-            $this->markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
+            self::markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
         }
 
         $deepl    = new DeepL(self::$authKey);
         $response = $deepl->languages('target');
 
         foreach ($response as $language) {
-            $this->assertArrayHasKey('language', $language);
-            $this->assertArrayHasKey('name', $language);
+            self::assertArrayHasKey('language', $language);
+            self::assertArrayHasKey('name', $language);
         }
     }
 
@@ -241,7 +251,7 @@ class DeepLApiTest extends TestCase
     public function testLanguagesFail()
     {
         if (self::$authKey === false) {
-            $this->markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
+            self::markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
         }
 
         $deepl    = new DeepL(self::$authKey);
@@ -253,12 +263,11 @@ class DeepLApiTest extends TestCase
 
     /**
      * Test translate() with all Params
-     * @throws DeepLException
      */
     public function testTranslateWithAllParams()
     {
         if (self::$authKey === false) {
-            $this->markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
+            self::markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
         }
 
         $deepl = new DeepL(self::$authKey);
@@ -280,23 +289,65 @@ class DeepLApiTest extends TestCase
             array('p','br')                //$splittingTags
         );
 
-        $this->assertEquals($expectedText, $translatedText[0]['text']);
+        self::assertEquals($expectedText, $translatedText[0]['text']);
     }
 
     /**
-     * Test translate() $formality
-     * @throws DeepLException
+     * Test translate() with all Params
      */
-    public function testTranslateFormality()
+    public function testWithProxy()
     {
         if (self::$authKey === false) {
             $this->markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
         }
 
+        if (self::$proxy === false) {
+            // The test would succeed with $proxy === false but it wouln't mean anything.
+            $this->markTestSkipped('Proxy is not configured.');
+        }
+
+        $deepl = new DeepL(self::$authKey);
+        $deepl->setProxy(self::$proxy);
+        $deepl->setProxyCredentials(self::$proxyCredentials);
+
+        $englishText  = 'please translate this text';
+        $expectedText = 'Bitte übersetzen Sie diesen Text';
+
+        $translatedText = $deepl->translate($englishText, 'en', 'de');
+
+        $this->assertEquals($expectedText, $translatedText[0]['text']);
+    }
+
+    /**
+     * Test translate() with all Params
+     */
+    public function testCustomTimeout()
+    {
+        $deepl = new DeepL(self::$authKey, 2, '10.255.255.1'); // non routable IP, should timeout.
+        $deepl->setTimeout(2);
+
+        $start = time();
+        try {
+            $deepl->translate('some text');
+        } catch (\Exception $e) {
+            $time = time() - $start;
+            $this->assertLessThan(4, $time);
+        }
+    }
+
+    /**
+     * Test translate() $formality
+     */
+    public function testTranslateFormality()
+    {
+        if (self::$authKey === false) {
+            self::markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
+        }
+
         $deepl = new DeepL(self::$authKey);
 
         $englishText    = '<strong>text to do not translate</strong><p>please translate this text</p>';
-        $expectedText   = '<stark>nicht zu übersetzender Text</stark><p>bitte diesen Text übersetzen</p>';
+        $expectedText   = '<strong>Nicht zu übersetzender Text</strong><p>Bitte übersetze diesen Text</p>';
         $translatedText = $deepl->translate(
             $englishText,
             'en',           //$sourceLanguage
@@ -306,42 +357,16 @@ class DeepLApiTest extends TestCase
             'less'                         //$formality
         );
 
-        $this->assertEquals($expectedText, $translatedText[0]['text']);
+        self::assertEquals($expectedText, $translatedText[0]['text']);
     }
-
-    /**
-     * Test translate() $formality
-     */
-    public function testTranslateFormalityFail()
-    {
-        if (self::$authKey === false) {
-            $this->markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
-        }
-
-        $deepl        = new DeepL(self::$authKey);
-        $englishText  = '<strong>text to do not translate</strong><p>please translate this text</p>';
-
-        $this->expectException('\BabyMarkt\DeepL\DeepLException');
-
-        $deepl->translate(
-            $englishText,
-            'en',           //$sourceLanguage
-            'es',        //$destinationLanguage
-            null,             //$tagHandling
-            null, //$ignoreTags
-            'more'                         //$formality
-        );
-    }
-
 
     /**
      * Test to Test the Tag-Handling.
-     * @throws DeepLException
      */
     public function testTranslateWithHTML()
     {
         if (self::$authKey === false) {
-            $this->markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
+            self::markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
         }
 
         $deepl           = new DeepL(self::$authKey);
@@ -357,7 +382,7 @@ class DeepLApiTest extends TestCase
             ),
             array(
                 'detected_source_language' => "EN",
-                'text'                     => "Ein weiterer Text neue Zeile <p>dies ist ein Absatz</p>",
+                'text'                     => "Ein weiterer Text<br>neue Zeile <p>dies ist ein Absatz</p></br> ",
             ),
 
         );
@@ -376,7 +401,7 @@ class DeepLApiTest extends TestCase
             array('p')
         );
 
-        $this->assertEquals($expectedArray, $translatedText);
+        self::assertEquals($expectedArray, $translatedText);
     }
 
     /**
@@ -385,7 +410,7 @@ class DeepLApiTest extends TestCase
     public function testTranslateWithNotSupportedSourceLanguage()
     {
         if (self::$authKey === false) {
-            $this->markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
+            self::markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
         }
 
         $deepl = new DeepL(self::$authKey);
@@ -400,12 +425,96 @@ class DeepLApiTest extends TestCase
     public function testTranslateWithNotSupportedDestinationLanguage()
     {
         if (self::$authKey === false) {
-            $this->markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
+            self::markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
         }
 
         $deepl = new DeepL(self::$authKey);
 
         $this->expectException('\BabyMarkt\DeepL\DeepLException');
         $deepl->translate('some txt', 'en', 'dk');
+    }
+
+    /**
+     * Test Glossary creation
+     */
+    public function testCreateGlossary()
+    {
+        if (self::$authKey === false) {
+            self::markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
+        }
+
+        $deepl    = new DeepL(self::$authKey);
+        $entries  = ['Hallo' => 'Hello'];
+        $glossary = $deepl->createGlossary('test', $entries, 'de', 'en');
+
+        self::assertArrayHasKey('glossary_id', $glossary);
+
+        return $glossary['glossary_id'];
+    }
+
+    /**
+     * Test Glossary listing
+     */
+    public function testListGlossaries()
+    {
+        if (self::$authKey === false) {
+            self::markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
+        }
+
+        $deepl      = new DeepL(self::$authKey);
+        $glossaries = $deepl->listGlossaries();
+
+        self::assertNotEmpty($glossaries['glossaries']);
+    }
+
+    /**
+     * Test listing information about a glossary
+     *
+     * @depends testCreateGlossary
+     */
+    public function testGlossaryInformation($glossaryId)
+    {
+        if (self::$authKey === false) {
+            self::markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
+        }
+
+        $deepl        = new DeepL(self::$authKey);
+        $information = $deepl->glossaryInformation($glossaryId);
+
+        self::assertArrayHasKey('glossary_id', $information);
+    }
+
+    /**
+     * Test listing entries in a glossary
+     *
+     * @depends testCreateGlossary
+     */
+    public function testGlossaryEntries($glossaryId)
+    {
+        if (self::$authKey === false) {
+            self::markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
+        }
+
+        $deepl   = new DeepL(self::$authKey);
+        $entries = $deepl->glossaryEntries($glossaryId);
+
+        self::assertEquals($entries, ['Hallo' => 'Hello']);
+    }
+
+    /**
+     * Test deleting a glossary
+     *
+     * @depends testCreateGlossary
+     */
+    public function testDeleteGlossary($glossaryId)
+    {
+        if (self::$authKey === false) {
+            self::markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
+        }
+
+        $deepl    = new DeepL(self::$authKey);
+        $response = $deepl->deleteGlossary($glossaryId);
+
+        self::assertNull($response);
     }
 }

--- a/tests/unit/DeepLTest.php
+++ b/tests/unit/DeepLTest.php
@@ -3,6 +3,7 @@
 namespace BabyMarkt\DeepL\unit;
 
 use BabyMarkt\DeepL\DeepL;
+use PHPUnit\Framework\TestCase;
 use PHPUnit_Framework_TestCase;
 use ReflectionClass;
 
@@ -12,7 +13,7 @@ use ReflectionClass;
  * @package BabyMarkt\DeepL
  * @SuppressWarnings(PHPMD.TooManyPublicMethods)
  */
-class DeepLTest extends PHPUnit_Framework_TestCase
+class DeepLTest extends TestCase
 {
     /**
      * Get protected method
@@ -42,7 +43,7 @@ class DeepLTest extends PHPUnit_Framework_TestCase
         $germanText = 'Hallo Welt';
         $deepl      = new DeepL($authKey);
 
-        $this->setExpectedException('\BabyMarkt\DeepL\DeepLException');
+        $this->expectException('\BabyMarkt\DeepL\DeepLException');
 
         $deepl->translate($germanText);
     }
@@ -446,7 +447,7 @@ class DeepLTest extends PHPUnit_Framework_TestCase
         $germanText = 'Hallo Welt';
         $deepl      = new DeepL($authKey);
 
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
 
         $deepl->translate($germanText, 'de', 'en', array('xml'));
     }


### PR DESCRIPTION
Hello, this PR proposal wishes to add the glossary feature added by DeepL to the library.

This PR:
 - Adds 5 new endpoints (create, delete, list, get glossary information, get glossary entries)
 - Modfies request method to handle GET and DELETE HTTP calls
 - Adds a new method handleResponse to manage null and string response from Deepl API
 - Updates tests for new endpoints
 - Updates readme

I tried to respect as much as possible the original code and style and tried to keep refactoring at a minimum, however I believe it could be further refactored to better handle different HTTP calls and API response which I'd gladly do if needed.

 