### PR TITLE
Added Glossary endpoints. Updated tests and endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,58 @@ echo 'You have used '.$usageArray['character_count'].' of '.$usageArray['charact
  
 ```
 
+### Glossary
+Create a glossary
+```php
+$glossary = $deepl->createGlossary('MyGlossary', ['Hallo' => 'Hello'], 'de', 'en');
+```
+
+| param               | Description                                                                                                                                                                                                                                                                                                                                                                                                               |
+|---------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| $name               | Glossary name
+| $entries            | Array of entries
+| $sourceLanguage     | The source language into which the glossary rule apply                                                                                                                                                                                                                                                                                                                                                                    |
+| $targetLanguage     | The target language into which the glossary rule apply                                                                                                                                                                                                                                                                                                                                             |
+
+Delete a glossary
+```php
+$glossary = $deepl->deleteGlossary($glossaryId);
+```
+
+| param               | Description                                                                                                                                                                                                                                                                                                                                                                                                               |
+|---------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| $glossaryId         | Glossary uuid (set by DeepL when glossary is created)
+
+List glossaries
+```php
+$glossaries = $deepl->listGlossaries();
+foreach ($glossaries as $glossary) {
+    var_dump($glossary);
+}
+```
+
+Get glossary meta information: creation date, is glossary ready to use ...
+```php
+$glossaryInformation = $deepl->glossaryInformation($glossaryId);
+var_dump($glossaryInformation);
+```
+
+| param               | Description                                                                                                                                                                                                                                                                                                                                                                                                               |
+|---------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| $glossaryId         | Glossary uuid (set by DeepL when glossary is created)
+
+Get glossary entries
+```php
+$entries = $deepl->glossaryEntries($glossaryId);
+foreach ($entries as $sourceLangText => $targetLangText) {
+    echo $sourceLangText .' > '.$targetLangText;
+}
+```
+
+| param               | Description                                                                                                                                                                                                                                                                                                                                                                                                               |
+|---------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| $glossaryId         | Glossary uuid (set by DeepL when glossary is created)
+
 ### Configuring cURL requests
 If you need to use a proxy, you can configure the underlying curl client to use one. You can also specify a timeout to avoid waiting for several minutes if Deepl is unreachable
 ```php

--- a/tests/integration/DeepLApiTest.php
+++ b/tests/integration/DeepLApiTest.php
@@ -228,7 +228,7 @@ class DeepLApiTest extends TestCase
     }
 
     /**
-     * Test languages()  can return the targe-languages
+     * Test languages()  can return the target-languages
      */
     public function testLanguagesTarget()
     {
@@ -432,5 +432,89 @@ class DeepLApiTest extends TestCase
 
         $this->expectException('\BabyMarkt\DeepL\DeepLException');
         $deepl->translate('some txt', 'en', 'dk');
+    }
+
+    /**
+     * Test Glossary creation
+     */
+    public function testCreateGlossary()
+    {
+        if (self::$authKey === false) {
+            self::markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
+        }
+
+        $deepl    = new DeepL(self::$authKey);
+        $entries  = ['Hallo' => 'Hello'];
+        $glossary = $deepl->createGlossary('test', $entries, 'de', 'en');
+
+        self::assertArrayHasKey('glossary_id', $glossary);
+
+        return $glossary['glossary_id'];
+    }
+
+    /**
+     * Test Glossary listing
+     */
+    public function testListGlossaries()
+    {
+        if (self::$authKey === false) {
+            self::markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
+        }
+
+        $deepl      = new DeepL(self::$authKey);
+        $glossaries = $deepl->listGlossaries();
+
+        self::assertNotEmpty($glossaries['glossaries']);
+    }
+
+    /**
+     * Test listing information about a glossary
+     *
+     * @depends testCreateGlossary
+     */
+    public function testGlossaryInformation($glossaryId)
+    {
+        if (self::$authKey === false) {
+            self::markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
+        }
+
+        $deepl        = new DeepL(self::$authKey);
+        $information = $deepl->glossaryInformation($glossaryId);
+
+        self::assertArrayHasKey('glossary_id', $information);
+    }
+
+    /**
+     * Test listing entries in a glossary
+     *
+     * @depends testCreateGlossary
+     */
+    public function testGlossaryEntries($glossaryId)
+    {
+        if (self::$authKey === false) {
+            self::markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
+        }
+
+        $deepl   = new DeepL(self::$authKey);
+        $entries = $deepl->glossaryEntries($glossaryId);
+
+        self::assertEquals($entries, ['Hallo' => 'Hello']);
+    }
+
+    /**
+     * Test deleting a glossary
+     *
+     * @depends testCreateGlossary
+     */
+    public function testDeleteGlossary($glossaryId)
+    {
+        if (self::$authKey === false) {
+            self::markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
+        }
+
+        $deepl    = new DeepL(self::$authKey);
+        $response = $deepl->deleteGlossary($glossaryId);
+
+        self::assertNull($response);
     }
 }


### PR DESCRIPTION
Hello, this PR proposal wishes to add the glossary feature added by DeepL to the library.

This PR:
   - Adds 5 new endpoints (create, delete, list, get glossary information, get glossary entries)
   - Modfies request method to handle GET and DELETE HTTP calls
   - Adds a new method handleResponse to manage null and string response from Deepl API
   - Updates tests for new endpoints
   - Updates readme

I tried to respect as much as possible the original code and style and tried to keep refactoring at a minimum, however I believe it could be further refactored to better handle different HTTP calls and API response which I'd gladly do if needed.