### PR TITLE
Implements glossary_id parameter

### DIFF
--- a/src/DeepL.php
+++ b/src/DeepL.php
@@ -64,6 +64,7 @@ class DeepL
      * @param array|null      $nonSplittingTags
      * @param null            $outlineDetection
      * @param array|null      $splittingTags
+     * @param string|null     $glossaryId
      *
      * @return array
      *
@@ -82,7 +83,8 @@ class DeepL
         $preserveFormatting = null,
         array $nonSplittingTags = null,
         $outlineDetection = null,
-        array $splittingTags = null
+        array $splittingTags = null,
+        $glossaryId = null
     ) {
         if (is_array($tagHandling)) {
             throw new InvalidArgumentException('$tagHandling must be of type String in V2 of DeepLLibrary');
@@ -99,6 +101,7 @@ class DeepL
             'split_sentences'     => $splitSentences,
             'preserve_formatting' => $preserveFormatting,
             'outline_detection'   => $outlineDetection,
+            'glossary_id'         => $glossaryId,
         );
 
         $paramsArray = $this->removeEmptyParams($paramsArray);


### PR DESCRIPTION
Hi,

We're missing the optionnal glossary_id parameter as described there : https://www.deepl.com/fr/docs-api/translating-text/request/