### PR TITLE
Reproduce Client Bug

### DIFF
--- a/tests/integration/GlossaryTest.php
+++ b/tests/integration/GlossaryTest.php
@@ -136,4 +136,21 @@ class GlossaryTest extends TestCase
 
         self::assertNull($response);
     }
+
+    public function testClientBugOnManyRequests_itThrowsWhenMakingARequestAfterADeleteRequest()
+    {
+        if (self::$authKey === false) {
+            self::markTestSkipped('DeepL Auth Key (DEEPL_AUTH_KEY) is not configured.');
+        }
+
+        $deepl    = new Glossary(self::$authKey);
+        $entries  = ['Hallo' => 'Hello'];
+        $glossary = $deepl->createGlossary('test', $entries, 'de', 'en');
+
+        $response = $deepl->deleteGlossary($glossary['glossary_id']);
+        self::assertNull($response);
+
+        // This line throws error "The Response seems to not be valid JSON."
+        $glossary = $deepl->createGlossary('test', $entries, 'de', 'en');
+    }
 }


### PR DESCRIPTION
Reproducer of #43 

If you reset the `$curl` instance right before handling the response the error goes away
```
// BabyMarkt\DeepL\Client

    public function request($url, $body = '', $method = 'POST')
    {
        ...

        if ($this->curl && is_resource($this->curl)) {
            curl_close($this->curl);
        }

        $this->curl = curl_init();
        curl_setopt($this->curl, CURLOPT_RETURNTRANSFER, 1);

        return $this->handleResponse($response, $httpCode);
    }
```